### PR TITLE
feat: Add support for running a RAFT cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,23 @@ To simply run all test cases, use this:
 cd raft
 go test -v -race ./...
 ```
+
+## Running a RAFT cluster
+
+You may start a RAFT process either locally or on a remote cluster with the following command.
+
+```bash
+go run main.go -id=<NODE_ID> -listen=<IP:PORT> -peers=<PEER_LIST>
+```
+
+- `<NODE_ID>`: Unique integer ID for this node (e.g., 0, 1, 2).
+- `<IP:PORT>`: The address this node should listen on (e.g., 127.0.0.1:9000).
+- `<PEER_LIST>`: Comma-separated list of peer nodes in the format `id=ip:port` (e.g., `1=127.0.0.1:9001,2=127.0.0.1:9002`).
+
+For instance, in order to run three RAFT servers locally on your machine, you can run each of the three comands below in a separate terminal window.
+
+```bash
+go run main.go -id=0 -listen=127.0.0.1:9000 -peers=1=127.0.0.1:9001,2=127.0.0.1:9002
+go run main.go -id=1 -listen=127.0.0.1:9001 -peers=0=127.0.0.1:9000,2=127.0.0.1:9002
+go run main.go -id=2 -listen=127.0.0.1:9002 -peers=0=127.0.0.1:9000,1=127.0.0.1:9001
+```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ go run main.go -id=<NODE_ID> -listen=<IP:PORT> -peers=<PEER_LIST>
 - `<IP:PORT>`: The address this node should listen on (e.g., 127.0.0.1:9000).
 - `<PEER_LIST>`: Comma-separated list of peer nodes in the format `id=ip:port` (e.g., `1=127.0.0.1:9001,2=127.0.0.1:9002`).
 
-For instance, in order to run three RAFT servers locally on your machine, you can run each of the three comands below in a separate terminal window.
+For instance, in order to run three RAFT servers locally on your machine, you can run each of the three commands below in a separate terminal window.
 
 ```bash
 go run main.go -id=0 -listen=127.0.0.1:9000 -peers=1=127.0.0.1:9001,2=127.0.0.1:9002

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module pucrs/sd
 go 1.24.1
 
 require github.com/fortytw2/leaktest v1.3.0
+
+require github.com/avast/retry-go v3.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"pucrs/sd/raft"
 	"strconv"
@@ -33,6 +34,7 @@ func main() {
 	server.Serve(listen)
 
 	connectToPeers(server, peerAddrs)
+	randomlySubmitCommands(server)
 
 	close(ready)
 
@@ -92,4 +94,18 @@ func connectToPeers(server *raft.Server, peerIdsToAddrs map[int]string) {
 			}
 		}(id, addr)
 	}
+}
+
+func randomlySubmitCommands(server *raft.Server) {
+	go func() {
+		for {
+			time.Sleep(time.Duration(3+rand.Intn(5)) * time.Second) // Random delay between 3 and 7 seconds
+			cmd := fmt.Sprintf("auto-cmd-%d", rand.Intn(10000))
+			if ok := server.Submit(cmd); ok {
+				log.Printf("submitted command: %s", cmd)
+			} else {
+				log.Printf("failed to submit command: %s", cmd)
+			}
+		}
+	}()
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,9 @@ func main() {
 	}
 
 	commitChan := make(chan raft.CommitEntry)
+	defer close(commitChan)
 	ready := make(chan any)
+
 	server := raft.NewServer(id, peerIds, ready, commitChan)
 	server.Serve(listen)
 

--- a/main.go
+++ b/main.go
@@ -95,7 +95,6 @@ func connectToPeer(server *raft.Server, peerId int, peerAddr string) error {
 			if err := server.ConnectToPeer(peerId, tcpAddr); err != nil {
 				return err
 			}
-			log.Printf("connected to peer %d at %s", peerId, peerAddr)
 			return nil
 		},
 		retry.Attempts(5),

--- a/main.go
+++ b/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"pucrs/sd/raft"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/avast/retry-go"
+)
+
+func main() {
+	var id int
+	var peers string
+	var listen string
+	flag.IntVar(&id, "id", 0, "server ID")
+	flag.StringVar(&peers, "peers", "", "comma-separated list of peerID=ip:port")
+	flag.StringVar(&listen, "listen", ":9000", "address to listen on")
+	flag.Parse()
+
+	peerIds, peerAddrs, err := parsePeersStr(peers)
+	if err != nil {
+		log.Fatalf("failed to parse peers: %v", err)
+	}
+
+	commitChan := make(chan raft.CommitEntry)
+	ready := make(chan any)
+	server := raft.NewServer(id, peerIds, ready, commitChan)
+	server.Serve(listen)
+
+	connectToPeers(server, peerAddrs)
+
+	close(ready)
+
+	// Print committed entries
+	for entry := range commitChan {
+		fmt.Printf("Committed: %+v\n", entry)
+	}
+}
+
+func parsePeersStr(peers string) (peerIds []int, peerIdsToAddrs map[int]string, err error) {
+	peerIds = make([]int, 0)
+	peerIdsToAddrs = make(map[int]string)
+
+	for _, p := range strings.Split(peers, ",") {
+		if len(p) == 0 {
+			continue
+		}
+
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) != 2 {
+			return nil, nil, fmt.Errorf("invalid peer format: %s, expected peerID=ip:port", p)
+		}
+
+		id, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid peer ID %s: %v", parts[0], err)
+		}
+
+		peerIds = append(peerIds, id)
+		peerIdsToAddrs[id] = parts[1]
+	}
+
+	return peerIds, peerIdsToAddrs, nil
+}
+
+func connectToPeers(server *raft.Server, peerIdsToAddrs map[int]string) {
+	for id, addr := range peerIdsToAddrs {
+		go func(id int, addr string) {
+			err := retry.Do(
+				func() error {
+					tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+					if err != nil {
+						return err
+					}
+					if err := server.ConnectToPeer(id, tcpAddr); err != nil {
+						return err
+					}
+					log.Printf("connected to peer %d at %s", id, addr)
+					return nil
+				},
+				retry.Attempts(5),
+				retry.DelayType(retry.BackOffDelay),
+				retry.Delay(1*time.Second),
+			)
+			if err != nil {
+				log.Printf("exhausted all attempts to connect to peer %d at %s: %v", id, addr, err)
+			}
+		}(id, addr)
+	}
+}

--- a/raft/server.go
+++ b/raft/server.go
@@ -53,6 +53,18 @@ func NewServer(serverId int, peerIds []int, ready <-chan any, commitChan chan<- 
 	return s
 }
 
+// Submit sends a command to the ConsensusModule for processing. It returns true
+// if this server is the leader and therefore the command was submitted successfully,
+// or false if this server is not the leader.
+func (s *Server) Submit(command any) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cm == nil {
+		return false
+	}
+	return s.cm.Submit(command)
+}
+
 func (s *Server) Serve(listenAddr string) {
 	s.mu.Lock()
 	s.cm = NewConsensusModule(s.serverId, s.peerIds, s, s.ready, s.commitChan)

--- a/raft/server.go
+++ b/raft/server.go
@@ -59,9 +59,6 @@ func NewServer(serverId int, peerIds []int, ready <-chan any, commitChan chan<- 
 func (s *Server) Submit(command any) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.cm == nil {
-		return false
-	}
 	return s.cm.Submit(command)
 }
 

--- a/raft/server.go
+++ b/raft/server.go
@@ -53,7 +53,7 @@ func NewServer(serverId int, peerIds []int, ready <-chan any, commitChan chan<- 
 	return s
 }
 
-func (s *Server) Serve() {
+func (s *Server) Serve(listenAddr string) {
 	s.mu.Lock()
 	s.cm = NewConsensusModule(s.serverId, s.peerIds, s, s.ready, s.commitChan)
 
@@ -64,7 +64,7 @@ func (s *Server) Serve() {
 	s.rpcServer.RegisterName("ConsensusModule", s.rpcProxy)
 
 	var err error
-	s.listener, err = net.Listen("tcp", ":0")
+	s.listener, err = net.Listen("tcp", listenAddr)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/raft/testharness.go
+++ b/raft/testharness.go
@@ -59,7 +59,7 @@ func NewHarness(t *testing.T, n int) *Harness {
 
 		commitChans[i] = make(chan CommitEntry)
 		ns[i] = NewServer(i, peerIds, ready, commitChans[i])
-		ns[i].Serve()
+		ns[i].Serve(":0") // let the OS assign a free port.
 	}
 
 	// Connect all peers to each other.


### PR DESCRIPTION
### AI-GENERATED SUMMARY

This pull request introduces significant updates to the RAFT implementation, including a new `main.go` entry point for running a RAFT cluster, enhancements to the RAFT server functionality, and documentation updates. These changes improve usability, connectivity, and testing flexibility.

### New RAFT Cluster Entry Point:
* Added a `main.go` file to allow users to start RAFT nodes with specified IDs, listening addresses, and peer configurations. It includes functions to parse peer strings, connect to peers with retry logic, and submit random commands periodically. (`main.go`, [main.goR1-R111](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R1-R111))

### Enhancements to RAFT Server:
* Introduced a `Submit` method in the `Server` class to allow submitting commands to the consensus module, returning success only if the server is the leader. (`raft/server.go`, [raft/server.goL56-R68](diffhunk://#diff-791d3a36a91651f0077ae666c38c5ad2b7ebb85e33d07ad7a2b30336b43ee821L56-R68))
* Modified the `Serve` method to accept a listening address as a parameter, enabling more flexible server configurations. (`raft/server.go`, [raft/server.goL67-R79](diffhunk://#diff-791d3a36a91651f0077ae666c38c5ad2b7ebb85e33d07ad7a2b30336b43ee821L67-R79))

### Testing Improvements:
* Updated the `Serve` method in the test harness to use dynamic port allocation (`:0`), allowing multiple RAFT servers to run without port conflicts during testing. (`raft/testharness.go`, [raft/testharness.goL62-R62](diffhunk://#diff-3fdab0327c0cb9e6e1608acbc9d200e6e978418e45c16a397134cd395ceca0eaL62-R62))

### Dependency Updates:
* Added the `github.com/avast/retry-go` library to handle retry logic for connecting to peers. (`go.mod`, [go.modR6-R7](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-R7))

### Documentation Updates:
* Expanded the `README.md` with instructions on running a RAFT cluster, including example commands for starting multiple nodes locally. (`README.md`, [README.mdR38-R57](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R57))