### PR TITLE
fix: Add support for peers returning from crash

### DIFF
--- a/raft/server.go
+++ b/raft/server.go
@@ -6,6 +6,7 @@
 package raft
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -13,8 +14,13 @@ import (
 	"net/rpc"
 	"os"
 	"sync"
+	"syscall"
 	"time"
+
+	"github.com/avast/retry-go"
 )
+
+const maxReconnectRetries = 1000 // retry "indefinitely"
 
 // Server wraps a raft.ConsensusModule along with a rpc.Server that exposes its
 // methods as RPC endpoints. It also manages the peers of the Raft server. The
@@ -36,6 +42,7 @@ type Server struct {
 
 	commitChan  chan<- CommitEntry
 	peerClients map[int]*rpc.Client
+	knownPeers  sync.Map // a map from the ID (int) to the address (*net.Addr) of known peers
 
 	ready <-chan any
 	quit  chan any
@@ -138,6 +145,9 @@ func (s *Server) GetListenAddr() net.Addr {
 func (s *Server) ConnectToPeer(peerId int, addr net.Addr) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, ok := s.knownPeers.Load(peerId); !ok {
+		s.knownPeers.Store(peerId, &addr)
+	}
 	if s.peerClients[peerId] == nil {
 		client, err := rpc.Dial(addr.Network(), addr.String())
 		if err != nil {
@@ -169,9 +179,55 @@ func (s *Server) Call(id int, serviceMethod string, args any, reply any) error {
 	// return an error.
 	if peer == nil {
 		return fmt.Errorf("call client %d after it's closed", id)
-	} else {
-		return peer.Call(serviceMethod, args, reply)
 	}
+
+	if err := peer.Call(serviceMethod, args, reply); err != nil {
+		log.Printf("peer %d is not responding - launching a thread to try to reconnect", id)
+		go func(peerId int, maxRetries int) {
+			if err := s.reconnectToPeer(id, maxRetries); err != nil {
+				log.Printf("failed to reconnect to peer %d, error %s", id, err)
+				return
+			}
+			log.Printf("successfully reconnected to peer %d!", id)
+		}(id, maxReconnectRetries)
+	}
+
+	return nil
+}
+
+// reconnectToPeer disconnects from the peer with the given ID if a connection exists
+// and keeps trying to reconnect with exponential backoff until the given maximum retries
+// are reached or an error different than connection refused is received. In such case,
+// this function will return a non-nil error.
+func (s *Server) reconnectToPeer(peerId int, maxRetries int) error {
+	s.DisconnectPeer(peerId)
+
+	err := retry.Do(
+		func() error {
+			peerEntry, ok := s.knownPeers.Load(peerId)
+			if !ok {
+				return retry.Unrecoverable(fmt.Errorf("peer with ID %d is unknown", peerId))
+			}
+
+			peerAddr, ok := peerEntry.(*net.Addr)
+			if !ok {
+				return retry.Unrecoverable(fmt.Errorf("peer with ID %d has an unexpected address format stored", peerId))
+			}
+
+			return s.ConnectToPeer(peerId, *peerAddr)
+		},
+		retry.Attempts(uint(maxRetries)),
+		retry.Delay(2*time.Second),
+		retry.DelayType(retry.BackOffDelay),
+		retry.RetryIf(func(err error) bool {
+			return errors.Is(err, syscall.ECONNREFUSED)
+		}),
+		retry.OnRetry(func(n uint, err error) {
+			log.Printf("reconnect retry #%d failed: %s", n, err)
+		}),
+	)
+
+	return err
 }
 
 // RPCProxy is a pass-thru proxy server for ConsensusModule's RPC methods. It

--- a/raft/server.go
+++ b/raft/server.go
@@ -181,18 +181,19 @@ func (s *Server) Call(id int, serviceMethod string, args any, reply any) error {
 		return fmt.Errorf("call client %d after it's closed", id)
 	}
 
-	if err := peer.Call(serviceMethod, args, reply); err != nil {
+	err := peer.Call(serviceMethod, args, reply)
+	if err != nil {
 		log.Printf("peer %d is not responding - launching a thread to try to reconnect", id)
 		go func(peerId int, maxRetries int) {
-			if err := s.reconnectToPeer(id, maxRetries); err != nil {
-				log.Printf("failed to reconnect to peer %d, error %s", id, err)
+			if err := s.reconnectToPeer(peerId, maxRetries); err != nil {
+				log.Printf("failed to reconnect to peer %d, error %s", peerId, err)
 				return
 			}
-			log.Printf("successfully reconnected to peer %d!", id)
+			log.Printf("successfully reconnected to peer %d!", peerId)
 		}(id, maxReconnectRetries)
 	}
 
-	return nil
+	return err
 }
 
 // reconnectToPeer disconnects from the peer with the given ID if a connection exists


### PR DESCRIPTION
### AI-GENERATED SUMMARY

This pull request enhances the `raft/server.go` file by introducing retry logic for peer reconnections, improving error handling, and adding a mechanism to track known peers. The changes aim to make it possible for peers to return from crash smoothly after an arbitrary period of time. Therefore, this PR closes #3, since the issue reported was caused by the fact that the peer coming back would not receive the `AppendEntries` RPCs sent by the leader because only the returning instance would try to reconnect to the others, but the others wouldn't try to reconnect to it.

### Retry Logic for Peer Reconnections:
* Added a `reconnectToPeer` method that uses the `retry-go` library to attempt reconnections with exponential backoff when a peer is unresponsive. It retries up to a configurable maximum (`maxReconnectRetries`) and stops on non-recoverable errors.
* Modified the `Call` method to initiate a reconnection attempt in a separate goroutine if a peer call fails, logging both successes and failures.

### Tracking Known Peers:
* Introduced a `sync.Map` named `knownPeers` in the `Server` struct to store peer IDs and their addresses.
* Updated the `ConnectToPeer` method to add peer information to `knownPeers` if it is not already present.

### Other Changes:
* Added the `retry-go` library and `syscall` package to handle retry logic and connection error identification.
* Defined a constant `maxReconnectRetries` to control the maximum number of reconnection attempts.